### PR TITLE
Update package.yml

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-20.04, macos-latest]
         python-version: [3.8]
 
     steps:


### PR DESCRIPTION
An error occurred in Ubuntu 20.04.6 LTS.
"dlopen: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found"