### PR TITLE
修复当文档被删除时，未能正确从搜索索引中移除的问题

### DIFF
--- a/core/index.py
+++ b/core/index.py
@@ -198,8 +198,7 @@ class WizIndex(object):
                             DT_MODIFIED=:DT_MODIFIED, DT_DATA_MODIFIED=:DT_DATA_MODIFIED, WIZ_VERSION=:WIZ_VERSION where DOCUMENT_GUID=:DOCUMENT_GUID"""
 
                         elif action == 'delete':
-                            writer.delete_by_term('path', r['DOCUMENT_GUID'])
-                            sql = """delete from WIZ_INDEX where DOCUMENT_GUID=:DOCUMENT_GUID"""
+                            self._handle_delete_action(writer, r)
                         else:
                             continue
 
@@ -222,6 +221,16 @@ class WizIndex(object):
                 zf.close()
         writer.commit()
         self.indexing = False
+
+    def _handle_delete_action(self, writer, data):
+        """处理删除文档的索引操作"""
+        writer.delete_by_term('path', data['DOCUMENT_GUID'])
+        sql = """DELETE FROM WIZ_INDEX WHERE DOCUMENT_GUID = :DOCUMENT_GUID"""
+        params = {
+            'DOCUMENT_GUID': data['DOCUMENT_GUID']
+        }
+        with self.index_db.get_connection() as conn:
+            conn.query(sql, **params)
 
     def search(self, keyword, page_num=1, search_in=None, folder_path=None,
                 create_start_date=None, create_end_date=None, 

--- a/core/index.py
+++ b/core/index.py
@@ -148,72 +148,52 @@ class WizIndex(object):
         count = len(index_data)
         if self.verbose:
             print('total: %s' % count, file=sys.stderr)
+        
         for i, v in enumerate(index_data):
             r = v['data']
             action = v['action']
             document_guid = r['DOCUMENT_GUID']
 
             zipfilename = os.path.join(self.wiz_path, 'notes/{%s}' % document_guid)
-            if not os.path.exists(zipfilename):
-                continue
+            content = self._extract_content_from_zip(zipfilename)
+
+            if self.verbose:
+                print('%s %s, %s' % (i, action, r['DOCUMENT_TITLE']), file=sys.stderr)
 
             try:
-                zf = zipfile.ZipFile(zipfilename)
-            except zipfile.BadZipFile as e:
+                if action == 'insert':
+                    self._handle_insert_action(writer, r, content)
+                elif action == 'update':
+                    self._handle_update_action(writer, r, content)
+                elif action == 'delete':
+                    self._handle_delete_action(writer, r)
+                else:
+                    continue
+            except Exception as e:
                 if self.verbose:
-                    print("Skip encrypted document", file=sys.stderr)
-                continue
+                    print(f"Error handling action {action} for {r['DOCUMENT_TITLE']}: {e}", file=sys.stderr)
 
-            for filename in zf.namelist():
-                if filename == 'index.html':
-                    try:
-                        data = zf.read(filename)
-                        html_content = BeautifulSoup(data, 'html5lib')
-                        content = html_content.body.text
-                        if self.verbose:
-                            print('%s %s, %s' % (i, action, r['DOCUMENT_TITLE']), file=sys.stderr)
-                        if action == 'insert':
-                            self._handle_insert_action(writer, r, content)
-                        elif action == 'update':
-                            writer.delete_by_term('path', r['DOCUMENT_GUID'])
-                            writer.update_document(
-                                path=r['DOCUMENT_GUID'],
-                                title=r['DOCUMENT_TITLE'],
-                                content=r['DOCUMENT_TITLE'] + '\n' + content,
-                                location=r['DOCUMENT_LOCATION'],
-                                create_time=datetime.strptime(r['DT_CREATED'], self.DATE_FORMAT),
-                                modify_time=datetime.strptime(r['DT_DATA_MODIFIED'], self.DATE_FORMAT)
-                            )
-
-                            sql = """update WIZ_INDEX set DOCUMENT_TITLE=:DOCUMENT_TITLE, 
-                            DOCUMENT_LOCATION=:DOCUMENT_LOCATION, DT_CREATED=:DT_CREATED, 
-                            DT_MODIFIED=:DT_MODIFIED, DT_DATA_MODIFIED=:DT_DATA_MODIFIED, WIZ_VERSION=:WIZ_VERSION where DOCUMENT_GUID=:DOCUMENT_GUID"""
-
-                        elif action == 'delete':
-                            self._handle_delete_action(writer, r)
-                        else:
-                            continue
-
-                        params = {
-                            'DOCUMENT_GUID': r['DOCUMENT_GUID'],
-                            'DOCUMENT_TITLE': r['DOCUMENT_TITLE'],
-                            'DOCUMENT_LOCATION': r['DOCUMENT_LOCATION'],
-                            'DT_CREATED': r['DT_CREATED'],
-                            'DT_MODIFIED': r['DT_MODIFIED'],
-                            'DT_DATA_MODIFIED': r['DT_DATA_MODIFIED'],
-                            'WIZ_VERSION': r['WIZ_VERSION']
-                        }
-                        with self.index_db.get_connection() as conn:
-                            conn.query(sql, **params)
-
-                    except Exception as e:
-                        if self.verbose:
-                            print(e, file=sys.stderr)
-            else:
-                zf.close()
         writer.commit()
         self.indexing = False
 
+    def _extract_content_from_zip(self, zipfilename):
+        if not os.path.exists(zipfilename):
+            return ""
+        try:
+            with zipfile.ZipFile(zipfilename, 'r') as zf:
+                if 'index.html' not in zf.namelist():
+                    return ""
+                data = zf.read('index.html')
+                html_content = BeautifulSoup(data, 'html5lib')
+                # 确保 body 存在，避免 AttributeError
+                if html_content.body:
+                    return html_content.body.get_text(strip=True)
+                else:
+                    return html_content.get_text(strip=True)  # fallback: 使用整个文档文本
+        except (zipfile.BadZipFile, Exception) as e:
+            if self.verbose:
+                print(f"Error reading zip file {zipfilename}: {e}", file=sys.stderr)
+            return ""
 
     def _handle_insert_action(self, writer, r, content):
         """处理插入文档的索引操作"""
@@ -239,6 +219,41 @@ class WizIndex(object):
         }
         with self.index_db.get_connection() as conn:
             conn.query(sql, **params)
+
+    def _handle_update_action(self, writer, r, content):
+        """处理更新文档的索引操作"""
+        # 删除旧的索引项
+        writer.delete_by_term('path', r['DOCUMENT_GUID'])
+        # 添加新的索引项
+        writer.update_document(
+            path=r['DOCUMENT_GUID'],
+            title=r['DOCUMENT_TITLE'],
+            content=r['DOCUMENT_TITLE'] + '\n' + content,
+            location=r['DOCUMENT_LOCATION'],
+            create_time=datetime.strptime(r['DT_CREATED'], self.DATE_FORMAT),
+            modify_time=datetime.strptime(r['DT_DATA_MODIFIED'], self.DATE_FORMAT)
+        )
+        # 更新数据库中的记录
+        sql = """UPDATE WIZ_INDEX 
+                SET DOCUMENT_TITLE = :DOCUMENT_TITLE, 
+                    DOCUMENT_LOCATION = :DOCUMENT_LOCATION, 
+                    DT_CREATED = :DT_CREATED, 
+                    DT_MODIFIED = :DT_MODIFIED, 
+                    DT_DATA_MODIFIED = :DT_DATA_MODIFIED, 
+                    WIZ_VERSION = :WIZ_VERSION 
+                WHERE DOCUMENT_GUID = :DOCUMENT_GUID"""
+        params = {
+            'DOCUMENT_GUID': r['DOCUMENT_GUID'],
+            'DOCUMENT_TITLE': r['DOCUMENT_TITLE'],
+            'DOCUMENT_LOCATION': r['DOCUMENT_LOCATION'],
+            'DT_CREATED': r['DT_CREATED'],
+            'DT_MODIFIED': r['DT_MODIFIED'],
+            'DT_DATA_MODIFIED': r['DT_DATA_MODIFIED'],
+            'WIZ_VERSION': r['WIZ_VERSION']
+        }
+        with self.index_db.get_connection() as conn:
+            conn.query(sql, **params)
+
 
     def _handle_delete_action(self, writer, data):
         """处理删除文档的索引操作"""

--- a/core/index.py
+++ b/core/index.py
@@ -169,25 +169,17 @@ class WizIndex(object):
                     try:
                         data = zf.read(filename)
                         html_content = BeautifulSoup(data, 'html5lib')
+                        content = html_content.body.text
                         if self.verbose:
                             print('%s %s, %s' % (i, action, r['DOCUMENT_TITLE']), file=sys.stderr)
                         if action == 'insert':
-                            writer.add_document(
-                                path=r['DOCUMENT_GUID'],
-                                title=r['DOCUMENT_TITLE'],
-                                content=r['DOCUMENT_TITLE'] + '\n' + html_content.body.text,
-                                location=r['DOCUMENT_LOCATION'],
-                                create_time=datetime.strptime(r['DT_CREATED'], self.DATE_FORMAT),
-                                modify_time=datetime.strptime(r['DT_DATA_MODIFIED'], self.DATE_FORMAT)
-                            )
-                            sql = """insert into WIZ_INDEX (DOCUMENT_GUID, DOCUMENT_TITLE, DOCUMENT_LOCATION, DT_CREATED, DT_MODIFIED,DT_DATA_MODIFIED, WIZ_VERSION) 
-                            values (:DOCUMENT_GUID, :DOCUMENT_TITLE, :DOCUMENT_LOCATION, :DT_CREATED, :DT_MODIFIED, :DT_DATA_MODIFIED, :WIZ_VERSION)"""
+                            self._handle_insert_action(writer, r, content)
                         elif action == 'update':
                             writer.delete_by_term('path', r['DOCUMENT_GUID'])
                             writer.update_document(
                                 path=r['DOCUMENT_GUID'],
                                 title=r['DOCUMENT_TITLE'],
-                                content=r['DOCUMENT_TITLE'] + '\n' + html_content.body.text,
+                                content=r['DOCUMENT_TITLE'] + '\n' + content,
                                 location=r['DOCUMENT_LOCATION'],
                                 create_time=datetime.strptime(r['DT_CREATED'], self.DATE_FORMAT),
                                 modify_time=datetime.strptime(r['DT_DATA_MODIFIED'], self.DATE_FORMAT)
@@ -221,6 +213,32 @@ class WizIndex(object):
                 zf.close()
         writer.commit()
         self.indexing = False
+
+
+    def _handle_insert_action(self, writer, r, content):
+        """处理插入文档的索引操作"""
+        writer.add_document(
+            path=r['DOCUMENT_GUID'],
+            title=r['DOCUMENT_TITLE'],
+            content=r['DOCUMENT_TITLE'] + '\n' + content,
+            location=r['DOCUMENT_LOCATION'],
+            create_time=datetime.strptime(r['DT_CREATED'], self.DATE_FORMAT),
+            modify_time=datetime.strptime(r['DT_DATA_MODIFIED'], self.DATE_FORMAT)
+        )
+        sql = """INSERT INTO WIZ_INDEX 
+                (DOCUMENT_GUID, DOCUMENT_TITLE, DOCUMENT_LOCATION, DT_CREATED, DT_MODIFIED, DT_DATA_MODIFIED, WIZ_VERSION) 
+                VALUES (:DOCUMENT_GUID, :DOCUMENT_TITLE, :DOCUMENT_LOCATION, :DT_CREATED, :DT_MODIFIED, :DT_DATA_MODIFIED, :WIZ_VERSION)"""
+        params = {
+            'DOCUMENT_GUID': r['DOCUMENT_GUID'],
+            'DOCUMENT_TITLE': r['DOCUMENT_TITLE'],
+            'DOCUMENT_LOCATION': r['DOCUMENT_LOCATION'],
+            'DT_CREATED': r['DT_CREATED'],
+            'DT_MODIFIED': r['DT_MODIFIED'],
+            'DT_DATA_MODIFIED': r['DT_DATA_MODIFIED'],
+            'WIZ_VERSION': r['WIZ_VERSION']
+        }
+        with self.index_db.get_connection() as conn:
+            conn.query(sql, **params)
 
     def _handle_delete_action(self, writer, data):
         """处理删除文档的索引操作"""

--- a/core/index.py
+++ b/core/index.py
@@ -20,7 +20,7 @@ from whoosh.query import And, Prefix, TermRange
 
 jieba.setLogLevel(jieba.logging.ERROR)
 
-
+MAX_SUPPORTED_INDEX_VERSION = 2 # 最大兼容版本号
 CURRENT_INDEX_VERSION = 2
 
 CREATE_WIZ_INDEX_TABLE_SQL = """
@@ -59,6 +59,7 @@ class WizIndex(object):
         self.index_path = os.path.join(base_path, "data")
         self.wiz_path = wiz_path
         self.index_db = records.Database('sqlite:///' + os.path.join(self.base_path, 'database.db'))
+        self.indexing = False
 
         try:
             with self.index_db.get_connection() as conn:
@@ -70,7 +71,7 @@ class WizIndex(object):
                     conn.query("INSERT INTO WIZ_INDEX_VERSION (name, version) VALUES ('version', 0)")
                 # 查询版本号，如果版本号小于2，需要重建索引
                 result = conn.query("SELECT version FROM WIZ_INDEX_VERSION WHERE name = 'version'").first()
-                if not result or result['version'] < 2:
+                if not result or result['version'] < MAX_SUPPORTED_INDEX_VERSION:
                     conn.query('DROP TABLE IF EXISTS WIZ_INDEX')
                     conn.query(CREATE_WIZ_INDEX_TABLE_SQL)
                     conn.query('PRAGMA auto_vacuum = FULL;')
@@ -78,7 +79,6 @@ class WizIndex(object):
 
                     if os.path.exists(self.index_path):
                         shutil.rmtree(self.index_path)
-
         except:
             pass
 
@@ -138,6 +138,10 @@ class WizIndex(object):
         return index_data
 
     def create_or_update_index(self):
+        if self.indexing:
+            print(f"已有索引任务正在进行，请稍后再试！")
+            return
+        self.indexing = True
         index_data = self.get_should_index_data()
         idx = self.get_idx()
         writer = idx.writer()
@@ -217,6 +221,7 @@ class WizIndex(object):
             else:
                 zf.close()
         writer.commit()
+        self.indexing = False
 
     def search(self, keyword, page_num=1, search_in=None, folder_path=None,
                 create_start_date=None, create_end_date=None, 


### PR DESCRIPTION
修复：当文档被删除时，未能正确从搜索索引中移除的问题
新增：如果本地没有同步远程文档，也可以通过title进行搜索。

本次提交对索引模块进行了重构，将原本聚合在一起的文档操作拆分为独立的方法，具体包括：
1、将文档删除逻辑抽离为独立方法
2、将文档插入逻辑抽离为独立方法
3、将文档更新逻辑抽离为独立方法
4、ZIP doc文件内容读取